### PR TITLE
修复了 array_reduce() 函数

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,10 +33,14 @@ function io_code_add_enlighter_assets() {
         // 判断是否存在代码块
         // 如果未找到块，则跳过加载资源
         if ( !$force_load ) {
-            $found_block = array_reduce( $posts, function($found, $post) { 
-                return $found || has_block( 'code', $post ) || preg_match('/(crayon-|<\/pre>)/i', $post->post_content, $matches);
-            }, false );
-            if ( !$found_block ) {
+            if (isset($posts) && is_array($posts)) {
+                $found_block = array_reduce( $posts, function($found, $post) { 
+                    return $found || has_block( 'code', $post ) || preg_match('/(crayon-|<\/pre>)/i', $post->post_content, $matches);
+                }, false );
+                if ( !$found_block ) {
+                    return;
+                }
+            } else {
                 return;
             }
         }


### PR DESCRIPTION
修复了 array_reduce() 函数使用时可能引发的警告问题。原代码中，$posts 变量可能为 null 或未定义，直接将其传递给 array_reduce() 会导致 PHP 抛出警告信息。为了增强代码的健壮性，添加了对 $posts 的检查逻辑，确保其已设置且为数组后再执行 array_reduce() 操作。